### PR TITLE
TYPO fix in polymorphic-methods.ipynb

### DIFF
--- a/notebooks/polymorphic-methods.ipynb
+++ b/notebooks/polymorphic-methods.ipynb
@@ -118,7 +118,7 @@
     "    ```scala\n",
     "    def isPrefix[A](p: Stack[A], s: Stack[A]): Boolean =\n",
     "        p.isEmpty || \n",
-    "            p.top == p.top && isPrefix(p.pop, s.pop)\n",
+    "            p.top == s.top && isPrefix(p.pop, s.pop)\n",
     "\n",
     "    val p = new EmptyStack[String].push(\"hello\")\n",
     "    val s = new EmptyStack[String].push(\"!\").push(\"world\").push(\"hello\")\n",


### PR DESCRIPTION
Typo when comparing p.top == s.top in isPrefix function